### PR TITLE
Fix code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/src/gizmos/text/StringBuilder.vue
+++ b/src/gizmos/text/StringBuilder.vue
@@ -24,7 +24,7 @@ export default {
             var result = "StringBuilder myString = new StringBuilder();" + newLine + newLine;
             var arrayOfLines = string.match(/[^\r\n]+/g);
             for (var i = 0; i < arrayOfLines.length; i++){
-                result += "myString.AppendLine(\"" + arrayOfLines[i].replace(/"/g, '\\"') + "\");" + newLine;
+                result += "myString.AppendLine(\"" + arrayOfLines[i].replace(/\\/g, '\\\\').replace(/"/g, '\\"') + "\");" + newLine;
             }
             result += newLine + "Console.WriteLine(myString.ToString());"
             return result;


### PR DESCRIPTION
Fixes [https://github.com/saracmert/devgizmos/security/code-scanning/1](https://github.com/saracmert/devgizmos/security/code-scanning/1)

To fix the problem, we need to ensure that both double quotes and backslashes are properly escaped in the input string. This can be achieved by using a regular expression with the `g` flag to replace all occurrences of double quotes and backslashes. Specifically, we should first escape backslashes and then escape double quotes to avoid any issues with the order of replacements.

The best way to fix the problem without changing existing functionality is to update the `replace` method on line 27 to handle both double quotes and backslashes. We will use two `replace` calls: one for backslashes and one for double quotes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
