### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: Workflow for Codecov
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/saracmert/devgizmos/security/code-scanning/4](https://github.com/saracmert/devgizmos/security/code-scanning/4)

To fix the issue, add a `permissions` block at the root of the workflow file. Since the workflow uploads coverage data to Codecov, it likely only requires `contents: read` permissions. This change ensures that the `GITHUB_TOKEN` has the minimal permissions necessary to perform the task, reducing the risk of unintended actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
